### PR TITLE
Fixed 2 test methods in SessionServiceUT

### DIFF
--- a/Backend/UnitTesting/SessionServiceUT.cs
+++ b/Backend/UnitTesting/SessionServiceUT.cs
@@ -135,7 +135,6 @@ namespace UnitTesting
         public void Delete_Session_NonExisting()
         {
             // Arrange
-            Guid nonExistingId = Guid.NewGuid();
             string nonExistingToken = Guid.NewGuid().ToString();
 
             var expectedResponse = nonExistingId;
@@ -143,7 +142,7 @@ namespace UnitTesting
             using (_db = new DatabaseContext())
             {
                 // Act
-                var response = ss.DeleteSession(_db, nonExistingToken, nonExistingId);
+                var response = ss.DeleteSession(_db, nonExistingToken);
                 // will return null if Session does not exist
                 _db.SaveChanges();
                 var result = _db.Sessions.Find(expectedResponse);
@@ -227,7 +226,7 @@ namespace UnitTesting
             {
                 newSession = ss.CreateSession(_db, newSession);
                 _db.SaveChanges();
-                var result = ss.GetSession(_db, newSession.Token, newUser.Id);
+                var result = ss.GetSession(_db, newSession.Token);
 
                 // Assert
                 Assert.IsNotNull(result);


### PR DESCRIPTION
# Issue/Ticket

CLOSES #XX
PROGRESS ON #XX

If you specify CLOSES, the ticket will be automatically closed and moved to 'done' when the PR is merged.

If you specify PROGRESS ON, a reference will be created to that issue (in both directions), but merging the PR will not close the issue.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Chore

Label your PR accordingly.

# How Has This Been Tested?

Please describe and list the tests that you wrote for each module changed. If there are any special considerations, mention them here.

- Test A
- Test B

# Notes

Put any notes here
