### PR TITLE
feature/dashboard-sorting

### DIFF
--- a/Frontend/src/views/Dashboard.vue
+++ b/Frontend/src/views/Dashboard.vue
@@ -143,13 +143,6 @@ export default {
       error: ""
     };
   },
-  watch: {
-    // Loading animation will need to be modified to finish when the app finishes launching
-    launchLoading(val) {
-      if (!val) return;
-      setTimeout(() => (this.launchLoading = false), 5000);
-    }
-  },
   methods: {
     launch(appId, app) {
       this.error = "";
@@ -177,8 +170,8 @@ export default {
                   break;
               }
             })
-            .finally( () => {
-              if (this.launchLoading !== false){
+            .finally(() => {
+              if (this.launchLoading !== false) {
                 this.launchLoading = false;
                 this.error =
                   "Communication with the application can not be established.";


### PR DESCRIPTION
# Issue/Ticket

CLOSES #XX
PROGRESS ON #XX

If you specify CLOSES, the ticket will be automatically closed and moved to 'done' when the PR is merged.

If you specify PROGRESS ON, a reference will be created to that issue (in both directions), but merging the PR will not close the issue.

# Description

Removed watch method for loading animation as requested 

## Type of change

Feature

# How Has This Been Tested?

When clicking on application, the loading animation no longer appears.

# Notes

N/A
